### PR TITLE
Remove generated protobuf artifacts and use build-time generation

### DIFF
--- a/paramiko_cloud/pki.py
+++ b/paramiko_cloud/pki.py
@@ -5,12 +5,14 @@ import secrets
 import time
 from typing import List, Tuple, Union, Dict, Optional
 
-from paramiko.dsskey import DSSKey
-from paramiko.ecdsakey import ECDSAKey
-from paramiko.ed25519key import Ed25519Key
+from paramiko import ECDSAKey, Ed25519Key, RSAKey
 from paramiko.message import Message
 from paramiko.pkey import PKey, PublicBlob
-from paramiko.rsakey import RSAKey
+
+try:
+    from paramiko import DSSKey
+except ImportError:  # pragma: no cover - only reached on newer Paramiko versions
+    DSSKey = None
 
 from paramiko_cloud.protobuf.csr_pb2 import CSR
 
@@ -330,7 +332,7 @@ class CertificateSigningRequest:
             public_key = Ed25519Key(public_key)
         elif key_type.startswith("ecdsa-sha2"):
             public_key = ECDSAKey(public_key)
-        elif key_type == "ssh-dss":
+        elif key_type == "ssh-dss" and DSSKey is not None:
             public_key = DSSKey(public_key)
         else:
             raise NotImplementedError("Key type not supported: {}".format(key_type))

--- a/paramiko_cloud/protobuf/__init__.py
+++ b/paramiko_cloud/protobuf/__init__.py
@@ -1,0 +1,3 @@
+from . import csr_pb2, rpc_pb2, rpc_pb2_grpc
+
+__all__ = ["csr_pb2", "rpc_pb2", "rpc_pb2_grpc"]

--- a/paramiko_cloud/test_pki.py
+++ b/paramiko_cloud/test_pki.py
@@ -1,20 +1,22 @@
 from unittest import TestCase
 
 from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
-from paramiko.dsskey import DSSKey
-from paramiko.ecdsakey import ECDSAKey
-from paramiko.rsakey import RSAKey
+from paramiko import ECDSAKey, RSAKey
 
-from paramiko_cloud.pki import CertificateSigningRequest, CertificateParameters
+from paramiko_cloud.pki import CertificateSigningRequest, CertificateParameters, DSSKey
 
 rsa_key = RSAKey.generate(1024)
-dss_key = DSSKey.generate(1024)
 ecdsa_key = ECDSAKey.generate(SECP256R1())
+dss_key = DSSKey.generate(1024) if DSSKey is not None else None
 
 
 class PKITest(TestCase):
     def test_certificate_signing_request_serializable(self):
-        for key in (rsa_key, dss_key, ecdsa_key):
+        keys = [rsa_key, ecdsa_key]
+        if dss_key is not None:
+            keys.append(dss_key)
+
+        for key in keys:
             with self.subTest("CSR from {} key can be serialized and deserialized".format(key.get_name())):
                 csr = CertificateSigningRequest(key, CertificateParameters())
                 csr_reconstructed = CertificateSigningRequest.from_proto(csr.to_proto())
@@ -22,3 +24,12 @@ class PKITest(TestCase):
                 for attr in dir(csr.cert_params):
                     if not attr.startswith("_"):
                         self.assertEqual(getattr(csr.cert_params, attr), getattr(csr_reconstructed.cert_params, attr))
+
+    def test_dss_key_type_handling(self):
+        csr = CertificateSigningRequest(rsa_key, CertificateParameters()).to_proto()
+        csr.publicKeyType = "ssh-dss"
+        if DSSKey is None:
+            with self.assertRaises(NotImplementedError):
+                CertificateSigningRequest.from_proto(csr)
+        else:
+            CertificateSigningRequest.from_proto(csr)


### PR DESCRIPTION
### Description
- Updated tests in `paramiko_cloud/test_pki.py` to conditionally include `DSSKey` (`dss_key = DSSKey.generate(1024) if DSSKey is not None else None`) and added an explicit test for `ssh-dss` handling that asserts `NotImplementedError` when `DSSKey` is unavailable and performs a round-trip when it is available.

### Testing
- Ran `git submodule update --init --recursive` to populate the `ssh-cert-proto` protobuf sources and the command completed successfully.
- Ran `python setup.py build_proto` to generate protobuf Python sources and the command completed successfully after submodule initialization.
- Ran `pytest -q` and all tests passed (`12 passed, 2 warnings, 18 subtests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be842a4c4832486700c5b74a58e2f)