### PR TITLE
Ignore tool caches and JetBrains churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
-.cache
+.cache/
+.*_cache/
 nosetests.xml
 coverage.xml
 *.cover
@@ -137,7 +138,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Covers JetBrains IDEs: IntelliJ, GoLand, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
@@ -153,7 +154,7 @@ cython_debug/
 # Generated files
 .idea/**/contentModel.xml
 
-# Sensitive or high-churn files]
+# Sensitive or high-churn files
 .idea/**/dataSources/
 .idea/**/dataSources.ids
 .idea/**/dataSources.local.xml
@@ -200,14 +201,27 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+# SonarLint plugin
+.idea/sonarlint/
+# see https://community.sonarsource.com/t/is-the-file-idea-idea-idea-sonarlint-xml-intended-to-be-under-source-control/121119
+.idea/sonarlint.xml
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
-# Editor-based Rest Client
+# Editor-based HTTP Client
 .idea/httpRequests
+http-client.private.env.json
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Apifox Helper cache
+.idea/.cache/.Apifox_Helper
+.idea/ApifoxUploaderProjectSetting.xml
+
+# Github Copilot persisted session migrations, see: https://github.com/microsoft/copilot-intellij-feedback/issues/712#issuecomment-3322062215
+.idea/**/copilot.data.migration.*.xml


### PR DESCRIPTION
Summary: updates .gitignore to ignore Ruff-style cache directories and the requested JetBrains high-churn/plugin files. Validation: git diff --check; git check-ignore for .ruff_cache and JetBrains entries; git ls-files -c -i --exclude-standard found no tracked files currently matching ignore rules.