### PR TITLE
Improve Sphinx documentation

### DIFF
--- a/docs/api/grpc.rst
+++ b/docs/api/grpc.rst
@@ -1,37 +1,22 @@
 gRPC
 ====
 
-Server implementation
----------------------
+The gRPC helper owns server setup and lifecycle. Application code still owns the
+``SignerServicer`` implementation and signing policy.
 
 .. automodule:: paramiko_cloud.grpc_server
    :members:
-   :undoc-members:
    :show-inheritance:
 
-Services
---------
-
-.. automodule:: paramiko_cloud.protobuf.rpc_pb2_grpc
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Protobuf messages
+Generated Modules
 -----------------
 
-.. autoclass:: paramiko_cloud.protobuf.csr_pb2.CSR
-   :members:
-   :undoc-members:
-   :show-inheritance:
+The protobuf and gRPC modules are generated into ``paramiko_cloud.protobuf`` by
+``scripts/build_proto.py``:
 
-.. autoclass:: paramiko_cloud.protobuf.rpc_pb2.CloudCertificateSigningRequest
-   :members:
-   :undoc-members:
-   :show-inheritance:
+* ``paramiko_cloud.protobuf.csr_pb2``
+* ``paramiko_cloud.protobuf.rpc_pb2``
+* ``paramiko_cloud.protobuf.rpc_pb2_grpc``
 
-.. autoclass:: paramiko_cloud.protobuf.rpc_pb2.CloudCertificateSigningResponse
-   :members:
-   :undoc-members:
-   :show-inheritance:
+They are not committed to the repository. Initialize the ``ssh-cert-proto``
+submodule and run the build script before importing them directly.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,13 @@
+API Reference
+=============
+
+The API reference documents the public classes used by the guide pages. The
+provider modules all expose an ``ECDSAKey`` class; the shared PKI module exposes
+certificate request, parameter, enum, and blob types.
+
+.. toctree::
+   :maxdepth: 2
+
+   keys
+   pki
+   grpc

--- a/docs/api/keys.rst
+++ b/docs/api/keys.rst
@@ -1,36 +1,45 @@
 Keys
 ====
 
-Base Key
---------
+Cloud-backed key classes adapt provider signing APIs to Paramiko's ECDSA key
+interface. They are certificate-authority keys as well as regular Paramiko
+signing keys.
+
+Shared Base Classes
+-------------------
+
+.. autoclass:: paramiko_cloud.base.CloudSigningKey
+   :members:
+   :show-inheritance:
 
 .. autoclass:: paramiko_cloud.base.BaseKeyECDSA
    :members:
-   :undoc-members:
    :show-inheritance:
    :exclude-members: generate, write_private_key, write_private_key_file
 
+Provider Implementations
+------------------------
 
-Amazon Web Services
--------------------
+AWS KMS
+^^^^^^^
 
 .. automodule:: paramiko_cloud.aws.keys
    :members:
-   :undoc-members:
    :show-inheritance:
+   :exclude-members: _AWSSigningKey
 
-Microsoft Azure
----------------
-
-.. automodule:: paramiko_cloud.azure.keys
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Google Cloud Platform
----------------------
+Google Cloud KMS
+^^^^^^^^^^^^^^^^
 
 .. automodule:: paramiko_cloud.gcp.keys
    :members:
-   :undoc-members:
    :show-inheritance:
+   :exclude-members: _GCPSigningKey
+
+Azure Key Vault
+^^^^^^^^^^^^^^^
+
+.. automodule:: paramiko_cloud.azure.keys
+   :members:
+   :show-inheritance:
+   :exclude-members: _AzureSigningKey

--- a/docs/api/pki.rst
+++ b/docs/api/pki.rst
@@ -1,9 +1,42 @@
 PKI
 ===
 
-This module provides SSH certificate signing functionality.
+The PKI module builds compact OpenSSH certificates and serializes certificate
+signing requests to protobuf for remote signing workflows.
 
-.. automodule:: paramiko_cloud.pki
+Certificate Model
+-----------------
+
+.. autoclass:: paramiko_cloud.pki.CertificateParameters
    :members:
-   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: paramiko_cloud.pki.CertificateSigningRequest
+   :members:
+   :show-inheritance:
+
+.. autoclass:: paramiko_cloud.pki.CertificateBlob
+   :members:
+   :show-inheritance:
+
+Signing Mixin
+-------------
+
+.. autoclass:: paramiko_cloud.pki.CertificateSigningKeyMixin
+   :members:
+   :show-inheritance:
+
+Enums
+-----
+
+.. autoclass:: paramiko_cloud.pki.CertificateType
+   :members:
+   :show-inheritance:
+
+.. autoclass:: paramiko_cloud.pki.CertificateCriticalOptions
+   :members:
+   :show-inheritance:
+
+.. autoclass:: paramiko_cloud.pki.CertificateExtensions
+   :members:
    :show-inheritance:

--- a/docs/cloud-keys.rst
+++ b/docs/cloud-keys.rst
@@ -1,0 +1,114 @@
+Cloud-Backed Keys
+=================
+
+Each provider exposes an ``ECDSAKey`` class that subclasses Paramiko's ECDSA key
+implementation. The private key remains inside the provider KMS. Paramiko-Cloud
+loads the public key, maps the provider signing API to Paramiko's signing
+interface, and returns DER-encoded ECDSA signatures to Paramiko.
+
+Cloud-backed keys can:
+
+* sign SSH data through ``sign_ssh_data``;
+* verify signatures with the public key material;
+* sign OpenSSH certificates with ``sign_certificate``;
+* render a public CA key line with ``pubkey_string``.
+
+Cloud-backed keys cannot export private key material or generate new keys
+locally. Use the provider KMS APIs or console to create the key before using it
+with Paramiko-Cloud.
+
+AWS KMS
+-------
+
+``paramiko_cloud.aws.keys.ECDSAKey`` creates its own ``boto3`` KMS client. Pass
+the KMS key ID or ARN as the first argument and any ``boto3.client("kms", ...)``
+keyword arguments after that.
+
+.. code-block:: python
+
+   from paramiko_cloud.aws.keys import ECDSAKey
+
+   ca_key = ECDSAKey(
+       "arn:aws:kms:us-east-1:012345678901:key/example-key-id",
+       region_name="us-east-1",
+   )
+
+The AWS key must have ``SIGN_VERIFY`` usage and one of these supported key and
+algorithm pairs:
+
+.. list-table::
+   :header-rows: 1
+
+   * - KMS key spec
+     - Signing algorithm
+   * - ``ECC_NIST_P256``
+     - ``ECDSA_SHA_256``
+   * - ``ECC_NIST_P384``
+     - ``ECDSA_SHA_384``
+   * - ``ECC_NIST_P521``
+     - ``ECDSA_SHA_512``
+
+The caller needs permission for ``kms:GetPublicKey`` during key construction and
+``kms:Sign`` for each signature.
+
+Google Cloud KMS
+----------------
+
+``paramiko_cloud.gcp.keys.ECDSAKey`` uses a caller-provided
+``KeyManagementServiceClient``. Pass the crypto key version resource name, not
+just the crypto key name, because asymmetric signing happens at the key version
+level.
+
+.. code-block:: python
+
+   from google.cloud import kms
+   from paramiko_cloud.gcp.keys import ECDSAKey
+
+   kms_client = kms.KeyManagementServiceClient()
+   key_version_name = (
+       "projects/example-project/locations/us-central1/"
+       "keyRings/ssh-ca/cryptoKeys/user-ca/cryptoKeyVersions/1"
+   )
+
+   ca_key = ECDSAKey(kms_client, key_version_name)
+
+Supported Google Cloud algorithms are ``EC_SIGN_P256_SHA256`` and
+``EC_SIGN_P384_SHA384``. The caller needs permission to get the public key and to
+asymmetrically sign with the selected key version.
+
+Azure Key Vault
+---------------
+
+``paramiko_cloud.azure.keys.ECDSAKey`` uses Azure Key Vault's key and crypto
+clients. Pass an Azure credential, the vault URL, and the key name.
+
+.. code-block:: python
+
+   from azure.identity import DefaultAzureCredential
+   from paramiko_cloud.azure.keys import ECDSAKey
+
+   credential = DefaultAzureCredential()
+
+   ca_key = ECDSAKey(
+       credential,
+       "https://example-vault.vault.azure.net/",
+       "ssh-user-ca",
+   )
+
+The Key Vault key must be an EC key. Signing supports the ``P-256``, ``P-384``,
+and ``P-521`` curves through Azure's ``ES256``, ``ES384``, and ``ES512``
+signature algorithms. The caller needs permission to read the key and perform
+cryptographic signing operations.
+
+Provider Choice
+---------------
+
+The certificate signing API is provider-neutral after construction:
+
+.. code-block:: python
+
+   cert = ca_key.sign_certificate(subject_key, ["alice"])
+
+Use provider-specific configuration only at the boundary where you create the CA
+key object. Keep certificate policy, validity, principals, and extensions in the
+shared PKI layer so the application code stays portable across providers.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,15 +6,12 @@
 
 # -- Path setup --------------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
 import subprocess
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(".."))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
 
 
 # -- Project information -----------------------------------------------------
@@ -33,6 +30,12 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
 ]
+
+autoclass_content = "both"
+autodoc_class_signature = "separated"
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+autodoc_mock_imports = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -53,10 +56,30 @@ html_theme = "alabaster"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
-# Build protobuf files
-subprocess.run(
-    ["python", "scripts/build_proto.py"],
-    cwd=os.path.realpath(os.path.join(os.path.dirname(__file__), "..")),
-)
+
+def _build_protobuf_sources() -> None:
+    """Generate protobuf modules when the proto submodule is available."""
+
+    proto_dir = ROOT / "ssh-cert-proto"
+    generated_files = list((ROOT / "paramiko_cloud" / "protobuf").glob("*_pb2*.py"))
+    if list(proto_dir.glob("*.proto")):
+        subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "build_proto.py")],
+            cwd=ROOT,
+            check=True,
+        )
+    elif not generated_files:
+        # Local checkouts may not have initialized the proto submodule yet.
+        # Mock generated modules so prose-only docs and API pages still build.
+        autodoc_mock_imports.extend(
+            [
+                "paramiko_cloud.protobuf.csr_pb2",
+                "paramiko_cloud.protobuf.rpc_pb2",
+                "paramiko_cloud.protobuf.rpc_pb2_grpc",
+            ]
+        )
+
+
+_build_protobuf_sources()

--- a/docs/grpc.rst
+++ b/docs/grpc.rst
@@ -1,0 +1,69 @@
+gRPC Signing Service
+====================
+
+Paramiko-Cloud includes a small wrapper around ``grpc.server`` for exposing a
+certificate signing service. The protobuf messages and service definitions are
+generated from the ``ssh-cert-proto`` submodule.
+
+``GRPCServer`` does not implement signing policy itself. You provide a
+``SignerServicer`` implementation, and the wrapper registers it, binds a port,
+and starts or stops the server as a context manager.
+
+Server Skeleton
+---------------
+
+.. code-block:: python
+
+   from paramiko_cloud.grpc_server import GRPCServer
+   from paramiko_cloud.pki import CertificateSigningRequest
+   from paramiko_cloud.protobuf import rpc_pb2, rpc_pb2_grpc
+
+
+   class Signer(rpc_pb2_grpc.SignerServicer):
+       def __init__(self, ca_key):
+           super().__init__()
+           self.ca_key = ca_key
+
+       def SignCertificate(self, request, context):
+           csr = CertificateSigningRequest.from_proto(
+               request.signingRequestPayload
+           )
+           cert = csr.sign(self.ca_key)
+
+           response = rpc_pb2.CloudCertificateSigningResponse()
+           response.certificateType = cert.key_type
+           response.certificate = cert.key_blob
+           return response
+
+       def GetCertificateAuthority(self, request, context):
+           response = rpc_pb2.GetCertificateAuthorityResponse()
+           response.keyType = self.ca_key.get_name()
+           response.publicKey = self.ca_key.asbytes()
+           return response
+
+
+   with GRPCServer(Signer(ca_key), bind_addr="[::]", port=50051):
+       wait_for_shutdown()
+
+Use ``server_credentials`` to bind a secure port:
+
+.. code-block:: python
+
+   with GRPCServer(
+       Signer(ca_key),
+       bind_addr="[::]",
+       port=50051,
+       server_credentials=credentials,
+   ):
+       wait_for_shutdown()
+
+Operational Notes
+-----------------
+
+* ``GRPCServer`` defaults to port ``50051`` and a thread pool with ten workers.
+* ``shutdown_grace`` is passed to ``grpc.Server.stop`` when the context exits.
+* The service implementation should enforce provider selection, key IDs,
+  authorization, audit logging, validity limits, and principal policy before
+  signing.
+* ``CertificateSigningRequest.from_proto`` supports RSA, ECDSA, Ed25519, and
+  DSS public keys when the installed Paramiko version still exposes DSS support.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,92 +1,42 @@
-Welcome to Paramiko-Cloud's documentation!
-==========================================
+Paramiko-Cloud
+==============
 
-This project aims to extend Paramiko to provide SSH keys that
-are backed by cloud-based key management services. Further,
-SSH certificate signing capabilities are added that make
-implementation of SSH certificate authorities straightforward.
+Paramiko-Cloud extends Paramiko with ECDSA keys whose private material stays in
+cloud key management services. The provider key classes behave like Paramiko
+``ECDSAKey`` objects, so they can sign SSH data and issue OpenSSH certificates
+without exporting the private key.
 
-.. toctree::
-   api/keys
-   api/pki
-   api/grpc
+The package also includes a small PKI layer for building OpenSSH certificate
+signing requests, serializing those requests through protobuf, and returning
+certificate lines that can be saved as ``*-cert.pub`` files.
 
-Installation
-------------
-Install Paramiko-Cloud using pip:
-
-.. code-block:: bash
-
-   # Install with AWS support
-   pip install paramiko-cloud[aws]
-
-   # Install with Azure support
-   pip install paramiko-cloud[azure]
-
-   # Install with GCP support
-   pip install paramiko-cloud[gcp]
-
-Examples
+Features
 --------
 
-Amazon Web Services
-^^^^^^^^^^^^^^^^^^^
+* AWS KMS, Google Cloud KMS, and Azure Key Vault ECDSA signing keys.
+* OpenSSH user and host certificate generation.
+* Certificate options, extensions, principals, serials, key IDs, and validity
+  windows.
+* Protobuf serialization for signing requests.
+* A gRPC server wrapper for exposing certificate signing services.
 
-.. code-block:: python
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
 
-   from paramiko_cloud.aws.keys import ECDSAKey
+   installation
+   usage
+   cloud-keys
+   grpc
 
-   ca_key = ECDSAKey(
-       "arn:aws:kms:ap-northeast-1:012345678901:key/e9a4e926-b826-46fe-840d-58d44f0c6a89",
-       region_name="ap-northeast-1"
-   )
-   client_key = RSAKey.generate(1024)
-   cert_string = ca_key.sign_certificate(
-       client_key,
-       ["test.user"]
-   ).cert_string()
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
 
-Microsoft Azure
-^^^^^^^^^^^^^^^
+   api/index
 
-.. code-block:: python
-
-   from azure.identity import DefaultAzureCredential
-   from paramiko_cloud.azure.keys import ECDSAKey
-
-   credential = DefaultAzureCredential()
-
-   ca_key = ECDSAKey(
-       credential,
-       "https://your.vault.url/",
-       "key_name"
-   )
-   client_key = RSAKey.generate(1024)
-   cert_string = ca_key.sign_certificate(
-       client_key,
-       ["test.user"]
-   ).cert_string()
-
-Google Cloud Platform
-^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-   from google.cloud import kms
-   from paramiko_cloud.gcp.keys import ECDSAKey
-
-   kms_client = kms.KeyManagementServiceClient()
-   key_name = "projects/PROJECT_NAME/locations/REGION_NAME/keyRings/YOUR_KEY_RING_NAME/cryptoKeys/YOUR_KEY_NAME/cryptoKeyVersions/YOUR_KEY_VERSION"
-
-   ca_key = ECDSAKey(kms_client, key_name)
-   client_key = RSAKey.generate(1024)
-   cert_string = ca_key.sign_certificate(
-       client_key,
-       ["test.user"]
-   ).cert_string()
-
-Indices and tables
-==================
+Indices and Tables
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,68 @@
+Installation
+============
+
+Paramiko-Cloud requires Python 3.10 or newer. Install the core package plus the
+extra for each cloud provider you plan to use.
+
+.. code-block:: bash
+
+   python -m pip install "paramiko-cloud[aws]"
+   python -m pip install "paramiko-cloud[gcp]"
+   python -m pip install "paramiko-cloud[azure]"
+
+Install all provider dependencies when you need more than one backend:
+
+.. code-block:: bash
+
+   python -m pip install "paramiko-cloud[all]"
+
+Provider Dependencies
+---------------------
+
+The extras install the SDK used by each key wrapper:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Extra
+     - Provider SDK
+     - Key class
+   * - ``aws``
+     - ``boto3``
+     - ``paramiko_cloud.aws.keys.ECDSAKey``
+   * - ``gcp``
+     - ``google-cloud-kms``
+     - ``paramiko_cloud.gcp.keys.ECDSAKey``
+   * - ``azure``
+     - ``azure-keyvault-keys`` and ``azure-identity``
+     - ``paramiko_cloud.azure.keys.ECDSAKey``
+
+Development Setup
+-----------------
+
+The repository uses ``uv`` for local workflows:
+
+.. code-block:: bash
+
+   git submodule update --init --recursive
+   uv sync --extra all --group dev --group docs
+   uv run python scripts/build_proto.py
+
+Generated protobuf modules are required before running type checks, tests, or
+building the API reference. The proto definitions live in the ``ssh-cert-proto``
+submodule and generated Python files are written to ``paramiko_cloud/protobuf``.
+
+Build the documentation locally with:
+
+.. code-block:: bash
+
+   uv run sphinx-build -b html docs docs/_build/html
+
+The project checks source code with:
+
+.. code-block:: bash
+
+   uv run ruff check .
+   uv run ruff format . --check
+   uv run mypy paramiko_cloud
+   uv run pytest --cov=./ --cov-report=xml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Requirements for docs build
+sphinx
 paramiko
 cryptography
 boto3

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,199 @@
+Certificate Signing
+===================
+
+Paramiko-Cloud signs OpenSSH certificates with the same high-level pattern for
+every provider:
+
+1. Create a cloud-backed ECDSA certificate authority key.
+2. Provide the public key that should receive a certificate.
+3. Choose principals, validity, certificate type, and options.
+4. Write the returned certificate line to the matching ``*-cert.pub`` file.
+
+The result is an OpenSSH certificate public key line, not an X.509
+certificate. OpenSSH certificates are compact SSH public-key records that bind a
+subject key to identity, validity, and policy fields signed by a trusted CA key.
+
+Signing a User Certificate
+--------------------------
+
+This example uses AWS KMS for the certificate authority key, but the
+``sign_certificate`` call is the same for AWS, Google Cloud, Azure, and any other
+Paramiko key that includes ``CertificateSigningKeyMixin``.
+
+.. code-block:: python
+
+   from datetime import timedelta
+
+   from paramiko import RSAKey
+
+   from paramiko_cloud.aws.keys import ECDSAKey
+   from paramiko_cloud.pki import CertificateExtensions
+
+   ca_key = ECDSAKey(
+       "arn:aws:kms:us-east-1:012345678901:key/example-key-id",
+       region_name="us-east-1",
+   )
+   subject_key = RSAKey.generate(3072)
+
+   cert = ca_key.sign_certificate(
+       subject_key,
+       principals=["alice"],
+       key_id="alice@example.com",
+       serial=1001,
+       valid_for=timedelta(hours=8),
+       extensions={
+           CertificateExtensions.PERMIT_PTY: "",
+           CertificateExtensions.PERMIT_AGENT_FORWARDING: "",
+       },
+   )
+
+   cert_line = cert.cert_string("alice@example.com")
+
+``cert_line`` is an OpenSSH certificate public key line. Save it next to the
+subject private key using OpenSSH's certificate naming convention, such as
+``id_rsa-cert.pub`` for ``id_rsa``.
+
+Certificate Parameters
+----------------------
+
+``sign_certificate`` accepts ``principals`` directly and forwards the remaining
+certificate configuration to ``CertificateParameters``.
+
+Common parameters are:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Purpose
+     - Default
+   * - ``principals``
+     - User names or host names valid for the certificate.
+     - Required by ``sign_certificate``.
+   * - ``type``
+     - ``CertificateType.USER`` or ``CertificateType.HOST``.
+     - ``CertificateType.USER``
+   * - ``key_id``
+     - Audit label stored in the certificate.
+     - Empty string
+   * - ``serial``
+     - CA-defined certificate serial number.
+     - ``0``
+   * - ``valid_after``
+     - Unix timestamp when the certificate becomes valid.
+     - Current time
+   * - ``valid_before``
+     - Unix timestamp when the certificate expires.
+     - ``valid_after + valid_for``
+   * - ``valid_for``
+     - Duration used when ``valid_before`` is not provided.
+     - One hour
+   * - ``critical_options``
+     - OpenSSH critical options.
+     - No critical options
+   * - ``extensions``
+     - OpenSSH extensions.
+     - All supported extensions enabled by ``sign_certificate``
+
+The certificate also includes a nonce, the subject public key, the CA public
+key, and a CA signature over the preceding certificate fields. Paramiko-Cloud
+handles those wire-format details when it builds the certificate.
+
+OpenSSH treats critical options as mandatory restrictions. If a client or server
+does not understand a critical option in a certificate, it must reject that
+certificate. Extensions are non-critical grants such as PTY or agent forwarding.
+Pass ``extensions={}`` when you want a certificate with no extensions.
+
+The standard extension values are empty strings:
+
+.. code-block:: python
+
+   extensions = {
+       CertificateExtensions.PERMIT_PTY: "",
+       CertificateExtensions.PERMIT_AGENT_FORWARDING: "",
+   }
+
+Critical option values carry option-specific data:
+
+.. code-block:: python
+
+   from paramiko_cloud.pki import CertificateCriticalOptions
+
+   critical_options = {
+       CertificateCriticalOptions.SOURCE_ADDRESS: "10.0.0.0/8,192.0.2.0/24",
+   }
+
+OpenSSH treats an empty principals list as valid for any principal of the
+certificate type. Prefer explicit principals for normal user and host
+certificates.
+
+Signing a Host Certificate
+--------------------------
+
+Host certificates use the same API with ``CertificateType.HOST``. Principals are
+the hostnames or address names that should validate against the host key.
+
+.. code-block:: python
+
+   from datetime import timedelta
+
+   from paramiko import ECDSAKey as ParamikoECDSAKey
+
+   from paramiko_cloud.gcp.keys import ECDSAKey as GCPECDSAKey
+   from paramiko_cloud.pki import CertificateType
+
+   ca_key = GCPECDSAKey(kms_client, key_version_name)
+   host_key = ParamikoECDSAKey.generate()
+
+   host_cert = ca_key.sign_certificate(
+       host_key,
+       principals=["web-01.example.com", "10.0.0.15"],
+       type=CertificateType.HOST,
+       key_id="web-01",
+       valid_for=timedelta(days=7),
+       extensions={},
+   )
+
+   host_cert_line = host_cert.cert_string("web-01.example.com")
+
+Public CA Key
+-------------
+
+Cloud-backed keys can expose their public key in OpenSSH format:
+
+.. code-block:: python
+
+   ca_public_key = ca_key.pubkey_string("production-user-ca")
+
+Private key export and local key generation are intentionally disabled for
+cloud-backed keys. Create and rotate the CA key in the provider's key management
+service, then point Paramiko-Cloud at the existing key.
+
+OpenSSH validates the certificate only when the CA public key is trusted by the
+server for user certificates or by the client for host certificates.
+
+Serializing Signing Requests
+----------------------------
+
+``CertificateSigningRequest`` can serialize a request to protobuf and reconstruct
+it later. This is the format used by the gRPC API.
+
+.. code-block:: python
+
+   from paramiko import RSAKey
+
+   from paramiko_cloud.pki import (
+       CertificateParameters,
+       CertificateSigningRequest,
+   )
+
+   request = CertificateSigningRequest(
+       RSAKey.generate(3072),
+       CertificateParameters(principals=["alice"], key_id="alice@example.com"),
+   )
+
+   proto = request.to_proto()
+   payload = proto.SerializeToString()
+   restored_proto = type(proto).FromString(payload)
+   restored = CertificateSigningRequest.from_proto(restored_proto)
+   cert = restored.sign(ca_key)


### PR DESCRIPTION
## Summary

Expanded the Sphinx documentation from a minimal API stub into a usable guide for installing Paramiko-Cloud, signing OpenSSH certificates, choosing cloud-backed key providers, and running the gRPC signing service.

Reworked the API reference so it supports the guide pages instead of being the only documentation surface. Updated the Sphinx configuration so docs can build locally even when generated protobuf modules are absent, while still regenerating protobuf modules when the submodule is available.

## Validation

- `.venv/bin/sphinx-build -W -E -b html docs docs/_build/html`
- `uv run --group docs sphinx-build -W -E -b html docs /tmp/paramiko-cloud-docs-html`
- `uv run ruff check docs`
- `uv run ruff format docs --check`
