### PR TITLE
Pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install build dependencies
         run: |
           uv sync --extra all --group build
@@ -57,11 +57,11 @@ jobs:
         run: uv build --sdist --wheel --out-dir dist/
       - name: Publish distribution 📦 to Test PyPI
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           verbose: true
           skip-existing: true
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
         run: |
           uv sync --extra all --group dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ Use `uv` for all local workflows.
 uv sync --extra all --group dev
 ```
 
+When using GitHub CLI (`gh`), escalate out of the sandbox so it can access the
+keyring-backed GitHub credentials.
+
 ## Required Build Step
 
 Some checks depend on generated protobuf files.


### PR DESCRIPTION
## Summary

- Pin third-party GitHub Actions in the test and publish workflows to immutable commit SHAs.
- Document that GitHub CLI commands need to run outside the sandbox so keyring-backed credentials are available.

## Validation

- `git diff --check`
- `git show --check --stat --oneline HEAD`
