### PR TITLE
Fix Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,17 @@
 version: 2
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
-  version: "3.11"
   install:
     - requirements: docs/requirements.txt
-  system_packages: true
+
 submodules:
   include: all
   recursive: true


### PR DESCRIPTION
## Summary

- Add the required Read the Docs v2 `build` block with Ubuntu 24.04 and Python 3.11.
- Explicitly point Sphinx at `docs/conf.py`.
- Remove legacy Python configuration keys that are no longer part of the supported v2 schema.

## Root Cause

Read the Docs now validates v2 configuration files against the explicit `build.os` and `build.tools` schema. The previous file used the older `python.version` layout and an unsupported system packages key, causing validation to fail before the docs build could start.

## Validation

- `ruby -e "require 'yaml'; p YAML.load_file('.readthedocs.yaml')"`
- `uv run --group docs sphinx-build -b html docs docs/_build/html`